### PR TITLE
単語追加機能-修正1

### DIFF
--- a/app/models/content.rb
+++ b/app/models/content.rb
@@ -4,7 +4,7 @@ class Content < ApplicationRecord
 
   with_options presence: true do
     validates :part_id, numericality: { other_than: 0 }
-    validates :word
+    validates :word, format: { with: /\A[a-z0-9]+\z/ }
   end
 
 end


### PR DESCRIPTION
# What
単語追加機能-修正1

# Why
contentモデルにてwordに対する入力値が半角アルファベット(小文字・数値)での登録のみを許可するように設定するため